### PR TITLE
Add Positive Integer Check for DAYS Argument

### DIFF
--- a/cleanmac.sh
+++ b/cleanmac.sh
@@ -33,6 +33,12 @@ done
 # Default to 7 days if no argument provided
 DAYS_TO_KEEP=${DAYS_TO_KEEP:-7}
 
+# Check that the number of days to keep is a positive integer
+if ! [[ $DAYS_TO_KEEP =~ ^[0-9]+$ ]]; then
+    echo "Error: DAYS must be a positive integer."
+    exit 1
+fi
+
 # Get initial disk space
 free_storage=$(df -k / | awk 'NR==2 {print $4}')
 total_storage=$(df -k / | awk 'NR==2 {print $2}')


### PR DESCRIPTION
This PR introduces a validation check to ensure that the DAYS argument provided to the script is a positive integer. This prevents the script from running with invalid or unintended inputs that could lead to errors or undesired behavior during the cleanup process.